### PR TITLE
Jira touchups

### DIFF
--- a/jira_tools/Gemfile
+++ b/jira_tools/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem 'rest-client'

--- a/jira_tools/README.md
+++ b/jira_tools/README.md
@@ -57,7 +57,9 @@ NOTES:
 
 This script creates a batch of Jira tickets
 
-* Input: a CSV file, based on one of the tables from https://simp-project.atlassian.net/wiki/spaces/SD/pages/1920008207/Test+Plan+SIMP+6.6.0
+* Input: a CSV file, based on one of the tables from https://simp-project.atlassian.net/wiki/spaces/SD/pages/1920008207/Test+Plan+SIMP+6.6.0 
+(Note: The most effective way to create this table is to select the table, copy it to google sheets [this seems to maintain the cells' integrity] and then file/download/CSV)
+
 
 ```console
 $ bundle exec ruby create_tix_from_confluence.rb -h
@@ -81,4 +83,5 @@ $ bundle exec ruby create_tix_from_confluence.rb -h
 
 -p Jira project (`JJTEST` by default, use `SIMP` when ready to go live)
 ```
+* Output: To ensure the run was successful, check the allresults.json
 

--- a/jira_tools/README.md
+++ b/jira_tools/README.md
@@ -1,10 +1,39 @@
 # Jira Tools
 
 
-## jira_pulls.rb
+<!-- vim-markdown-toc GFM -->
 
+* [Setup](#setup)
+  * [Obtaining Jira credentials](#obtaining-jira-credentials)
+* [Usage](#usage)
+  * [jira_pulls.rb](#jira_pullsrb)
+  * [create_tix_from_confluence.rb](#create_tix_from_confluencerb)
 
-$ ruby jira_pulls.rb -h
+<!-- vim-markdown-toc -->
+
+## Setup
+
+1. Run `bundle` to install Gem dependencies
+2. Ensure the environment variable `JIRA_API_TOKEN` is set in `<login>:<token>` format (for create_tix_from_confluence.rb only):
+
+   ```sh
+   export JIRA_API_TOKEN=me@here.com:123456789012
+   ```
+### Obtaining Jira credentials
+
+To get your API token:
+
+* In Jira, click your profile (top-right
+  * Account settings
+  * Security
+  * Api token
+
+## Usage
+
+### jira_pulls.rb
+
+```console
+$ bundle exec ruby jira_pulls.rb -h
 
      Usage: jira_pull [options] (default will pull only the current sprint)
 
@@ -19,21 +48,25 @@ $ ruby jira_pulls.rb -h
 
 -o will copy the output file to the specified directory (please use a full path)
 
-NOTES: 
-* the default option is current sprint 
+NOTES:
+* the default option is current sprint
 * the -s and -d options cannot be used together
+```
 
+### create_tix_from_confluence.rb
 
+This script creates a batch of Jira tickets
 
-## create_tix_from_confluence.rb -h
+* Input: a CSV file, based on one of the tables from https://simp-project.atlassian.net/wiki/spaces/SD/pages/1920008207/Test+Plan+SIMP+6.6.0
 
-$ ruby create_tix_from_confluence.rb -h
+```console
+$ bundle exec ruby create_tix_from_confluence.rb -h
 
     Usage: create_tickets [options]
 
       -h, --help                       Help
-      -f, --input NAME                 Input file or directory name
-      -s, --sprint NUMBER              Input sprint number (Jira)
+      -f, --input NAME                 CSV Input file or directory name
+      -p, --project PROJECT            Jira Project to create tickets (default: JJTEST)
 
 -f input file (should be a comma-separated file containing the fields:
 
@@ -44,8 +77,8 @@ $ ruby create_tix_from_confluence.rb -h
   * component (component name)
   * blocker (if a previous ticket blocks it, put its ticket id here)
   * points (story points)
-  
 
 
--s sprint number assigned by Jira (you may need to look it up, usually by hovering over a report option)
+-p Jira project (`JJTEST` by default, use `SIMP` when ready to go live)
+```
 

--- a/jira_tools/initial_release_candidate_tickets.csv
+++ b/jira_tools/initial_release_candidate_tickets.csv
@@ -1,0 +1,128 @@
+ID,Ticket Summary (< 100 chars),Description,Component,Blockers,Story Points,EL7,EL8,OEL7,OEL8,RH7,RH8,Notes
+1,Release Components,"Identify components to be released, verify tests pass, push annotated tags, update SIMP release confluence page. https://simp.readthedocs.io/en/latest/contributors_guide/maintenance/Tagging_and_Releasing_Components.html",,-,3,-,-,-,-,-,-,
+1.1,Identify components to release,,,-,1,-,-,-,-,-,-,
+1.2,Release components,,,1.1,2,-,-,-,-,-,-,
+2,Create initial SIMP changelog,"Examine changes made to the simp-core project since the previous SIMP release tag (e.g., SIMP-6.5.0-1), as well as changes made to its SIMP dependencies listed in the Puppetfile.pinned. 
+For simp-core changes, examine the following:
+simp-core changes noted in its git logs
+
+src/assets/simp/build/simp.spec %changelog changes
+
+For changes for an individual SIMP component, examine changes noted both in its git logs and its CHANGELOG file or %changelog section of its build/<component>.spec file. The changes to examine are those from the version listed in the Puppetfile.pinned of the last SIMP release.",simp-doc,,8,-,-,-,-,-,-,"This changelog needs to be done early because it informs what release-specific tests need to be executed and which sections of the documentation may need updates.
+
+This is a tedious, time-consuming job!
+
+Liz and Jeanne both have utilities to gather the changes. 
+
+The deps:changelog rake task in simp-core should not be used because it does not accurately take into account individual component changes."
+2.1,Create changelog,,,,6,-,-,-,-,-,-,
+2.2,Review changes,,,2.1,2,-,-,-,-,-,-,
+3,Update simp-core pre-release tests with release-specific changes,"Update simp-core default, ipa, install_from_tar, and simp_lite acceptance test suites for release-specific changes. This includes updating the nodesets and .gitlab-ci.yml for any changes to the supported OSs.",simp-core,-,5,-,-,-,-,-,-,"Ideally, this should be done after the initial changelog has been generated, as the changelog informs the work to be done.
+Tests will be executed for the appropriate OSs permutations in the nodeset, but separate tickets per OS should not be created."
+3.1,Update tests and nodesets,,,-,4,-,-,-,-,-,-,
+3.2,Review updates,,,3.2,1,-,-,-,-,-,-,
+4,Update simp-packer with release-specific changes,"Update simp-packer for release-specific changes. Be sure to tag the previous simp-packer version, if the updates will break testing functionality built for the prior SIMP release.",simp-packer,-,3,-,-,-,-,-,-,"Ideally, this should be done after the initial changelog has been generated, as the changelog informs the work to be done."
+4.1,Update code and documentation,,,-,2,-,-,-,-,-,-,
+4.2,Review changes,,,4.1,1,-,-,-,-,-,-,
+5,Identify release-specific tests and documentation updates,"Based on the initial Changelog for the release, identify (1) integration tests that must be done with a fully configured SIMP server and (if necessary) clients and (2) simp-doc documentation that may be affected by the changes. The tests should be tests that are not adequately tested in component acceptance tests.",,2,7,-,-,-,-,-,-,
+5.1,Determine release-specific manual tests,,,,4,,,,,,,
+5.2,Determine simp-doc pages that need to be reviewed for accuracy or revised,Identify pages that require an in-depth examination or major revision,,,2,-,-,-,-,-,-,
+5.3,Create tickets for each test and simp-doc page review,,,"5.1, 5.2",1,-,-,-,-,-,-,
+6,Update simp-core with released components,"Update simp-core files (Puppetfile.pinned, metadata.json, src/assets/simp/build/simp.spec) and verify ISOs can be built and the default, ipa, and simp_lite acceptance test suites pass. 
+You must set the SIMP_FULL_MATRIX variable to have all the tests run in a GitLab.",simp-core,"1, 3",3,-,-,-,-,-,-,
+6.1,Update files and build ISOs for supported OSs,You may need to update package lists for the ISO builds.,,-,2,-,-,-,-,-,-,
+6.2,Verify acceptance tests,"Verify the default, ipa, and simp_lite acceptance tests pass with new components. No major test revisions should be needed.",,6.1,1,-,-,-,-,-,-,Tests should already been updated for major changes in ID 3 in this table.
+6.3,Review updates,"Make sure to verify versions in Puppetfile.pinned, metdata.json and src/assets/simp/build/simp.spec.",,6.2,1,-,-,-,-,-,-,
+7,"Create test ISO, and publish the ISO and its tar file",,simp-core,6,2,Y,Y,-,-,-,-,"This step may actually have to be done several times before we get to an initial release candidate build that can be published. If additional tickets are warranted, they can be created on the fly."
+7.1,Build ISO,Use official RPM signing keys when the artifacts are to be published anywhere at simp-project.com.,,-,1,-,-,-,-,-,-,
+7.2,Publish artifacts,Interim artifacts may be published to unstable folders at simp-project.com or other unofficial shared locations.,,7.1,1,-,-,-,-,-,-,
+8,Validate ISO by building packer boxes (BIOS and UEFI),Use simp-packer to build SIMP server packer boxes. Basic bootstrap validation is done as part of the packer build.,,7,,Y,Y,-,-,-,-,
+8.1,Validate ISO by building packer boxes (BIOS),"Use simp-packer to build SIMP server packer boxes. Basic bootstrap validation is done as part of the packer build.
+BIOS boot box FIPS-enabled, encrypted disk
+
+BIOS boot box FIPS-enabled, unencrypted disk
+
+BIOS boot box FIPS-disabled, encrypted disk
+
+BIOS boot box FIPS-disabled, unencrypted disk",,7,,Y,Y,-,-,-,-,
+8.2,Validate ISO by building packer boxes (UEFI),"Use simp-packer to build SIMP server packer boxes. Basic bootstrap validation is done as part of the packer build.
+UEFI boot box FIPS-enabled, encrypted disk
+
+UEFI boot box FIPS-enabled, unencrypted disk
+
+UEFI boot box FIPS-disabled, encrypted disk
+
+UEFI boot box FIPS-disabled, unencrypted disk",,,,,,,,,,
+9,Verify installation from RPMs in tar file,Run simp-core’s install_from_tar test using the tar file generated from an ISO build.,simp-core,7,-,-,-,-,-,-,-,
+9.1,Execute test,See https://github.com/simp/simp-core/blob/master/spec/acceptance/suites/README.md for description of environment variables that can be set to point to the tar file.,,,1,Y,Y,-,-,-,-,
+10,Create upgrade instructions,Document any steps that are needed outside of the generic upgrade instructions. Also look for any unusual messages emitted during RPM upgrade.,simp-doc,7,10,Y,Y,-,-,-,-,
+10.1,Manually execute upgrade with FIPS enabled,,,,4,-,-,-,-,-,-,
+10.2,Manually execute upgrade with FIPS disabled,,,,1,-,-,-,-,-,-,
+10.3,Write upgrade instructions,,,,4,-,-,-,-,-,-,
+10.4,Review instructions,"Review the instructions for clarity, grammar, spelling, formatting, etc. Verification will be done in a separate ticket",,10.3,1,-,-,-,-,-,-,
+11,Verify upgrade instructions,Verify upgrade instructions and make any necessary adjustments to them.,simp-doc,10,,Y,Y,-,-,-,-,
+11.1,Execute instructions,,,,2,-,-,-,-,-,-,
+11.2,Update instructions,,,,1,-,-,-,-,-,-,
+12,Verify PXE boot UEFI,Manually verify clients can PXE boot (UEFI) from a SIMP-managed tftpboot server.,,,,,,,,,,
+"contains links to tickets with descriptions of what others have done previously to test these capabilities.
+
+
+Verify PXE boot (UEFI) FIPS enabled, disk encrypted, same OS as tftpboot server
+
+Verify PXE boot (UEFI) FIPS enabled, disk unencrypted, same OS as tftpboot server
+
+Verify PXE boot (UEFI) FIPS disabled, disk encrypted, same OS as tftpboot server
+
+Verify PXE boot (UEFI) FIPS disabled, disk unencrypted, same OS as tftpboot server
+
+Verify PXE boot (UEFI) FIPS enabled, disk encrypted, clients from tftpboot server of different OS",,7,,Y,Y,-,-,-,-,TODO: Automate these tests,,
+13,Verify PXE boot BIOS,"Manually verify clients can PXE boot (BIOS) from a SIMP-managed tftpboot server
+ 
+Verify PXE boot (BIOS) FIPS enabled, disk encrypted, same OS as tftpboot server
+
+Verify PXE boot (BIOS) FIPS enabled, disk unencrypted, same OS as tftpboot server
+
+Verify PXE boot (BIOS) FIPS disabled, disk encrypted, same OS as tftpboot server
+
+Verify PXE boot (BIOS) FIPS disabled, disk unencrypted, same OS as tftpboot server
+
+Verify PXE boot (BIOS) FIPS enabled, disk encrypted, clients from tftpboot server of different OS",,7,,Y,Y,-,-,-,-,ODO: Finish automation of these tests
+14,Verify non-standard ISO UEFI boot options,Manually verify the choose your own partitions and minimum installation ISO boot options,,7,,Y,Y,-,-,-,-,
+14.1,Verify the choose your own partitions option,,,,,-,-,-,-,-,-,
+14.2,Verify the minimum installation option,,,,,-,-,-,-,-,-,
+15,Verify non-standard ISO BIOS boot options,Manually verify the ‘choose your own partitions' and ‘minimum installation’ ISO boot options,,7,,Y,Y,-,-,-,-,
+15.1,Verify the choose your own partitions option,,,,,-,-,-,-,-,-,
+15.2,Verify the minimum installation option,,,,,-,-,-,-,-,-,
+16,Dogfood released modules and assets,Use released modules in development environments that exercise as many of the modules as possible. Install RPMs of released assets on SIMP servers.,,6,,Y,Y,-,-,-,-,
+16.1,Deploy modules to development environments,Update Puppetfiles for development environments and deploy the modules.,,,,-,-,-,-,-,-,
+16.2,Install asset RPMs on SIMP server,Install RPMs and watch for any RPM installation error messages.,,,,-,-,-,-,-,-,
+16.3,Examine logs for issues,,,"16.1, 16.2",,-,-,-,-,-,-,
+17,Execute misc manual tests,Miscellaneous tests that are not addressed (fully) with automation.,,6,,Y,Y,-,-,-,-,
+17.1,Verify rsyslog local and forwarded logging in simp-core default suite,"simp-core's default suite has an extensive rsyslog integration test for local logging and log forwarding that does not use a mock sender ('logger'). Due to rsyslog itself, the rsyslog forwarding verifications have proven to be unreliable. As a stopgap measure, the tests were modified to skip any rsyslog test that fails in the simp-core default suite, in lieu of failing. Unfortunately, this has the potential to hide actual problems. So this ticket is to verify manually that all the failed checks executed in this test actually work.",,,1,-,-,-,-,-,-,
+17.2,Verify compliance report in simp-core default suite,Examine the compliance report generated by the simp-core default suite and verify there are no incorrect mappings or unexpected non-compliance. (There will be some non-compliance for overrides that allow the test to run.),,,1,-,-,-,-,-,-,
+18,Verify poss scenario,Manually verify SIMP server and a client operate under the expected security measures when the SIMP server is bootstrapped with the ‘poss’ scenario.,,,,Y,Y,-,-,-,-,"Verify using a SIMP server and kickstart client with the same OS.
+TODO: Automate this test"
+18.1,Bootstrap a SIMP server and verify all security measures are enforced.,,,,,-,-,-,-,-,-,
+18.2,Kick a client and verify no security measures are enforced,"If the auditd service is running, it has no rules. ('auditctl -l' returns 'No rules’)
+
+If the firewalld service is running, the default zone is not the 99_simp zone. ('firewall-cmd --get-default-zone' returns 'public')
+
+haveged service does not exist. ('systemctl status haveged' returns 'Unit haveged.service could not be found.')
+
+logrotate configuration, /etc/logrotate.conf, does not have 'include /etc/logrotate.simp.d'
+
+pam configuration, /etc/pam.d/system-auth does not have ""This file managed by Puppet""
+
+SIMP-specific PKI directories, /etc/pki/simp/ and /etc/pki/simp_apps/, do not exist.
+
+sssd service should not be running and should not be configured. ( 'systemctl status sssd' returns 'Active: inactive (dead) and there is no/etc/sssd/sssd.conf)
+
+stunnel service does not exist. ( 'systemctl status stunnel' returns 'Unit stunnel.service could not be found.')
+
+rsyslog service may be running but is not configured for SIMP, i.e.
+/etc/rsyslog.conf does not have '$IncludeConfig /etc/rsyslog.simp.d/*.conf'
+
+tcpwrappers is not configured on OSs that support tcpwrappers. (If /etc/hosts.allow exists, it is just comments. Same for /etc/hosts.deny )",,,,-,-,-,-,-,-,
+19,Benchmark with SCAP scan,This test is intended to find deficiencies in the enforced DISA STIG security settings for SIMP modules,,,,Y,Y,-,-,-,-,
+19.1,Execute scan and analyze results,"Execute the SCAP scan on a FIPS-enabled, disk-encrypted SIMP server packer box for which compliance has been enforced and then analyze the results for any SIMP deficiencies. Looking for system configuration that is not correctly configured for which the compliance report does not indicate an exception. Check may reveal component behavior or component compliance data that needs to be updated.",,,,-,-,-,-,-,-,
+19.2,Create tickets for deficiencies,Create tickets for any component deficiencies found.,,,,-,-,-,-,-,-,


### PR DESCRIPTION
Minor touch-ups with the Jira scripts:

* Update README with setup, TOC

* Add options so you don't need to modify source code when
   changing settings in `create_tix_from_confluence.rb`:
  * Use env var `JIRA_API_TOKEN` for Jira credentials
  * Add `--project PROJECT` option (default: `JJTEST`)

* Add `initial_release_candidate_tickets.csv` to test create script